### PR TITLE
[UPD] Some speed optimizations

### DIFF
--- a/LFHeatMapDemo/LFHeatMapDemo.xcodeproj/project.xcworkspace/xcshareddata/LFHeatMapDemo.xccheckout
+++ b/LFHeatMapDemo/LFHeatMapDemo.xcodeproj/project.xcworkspace/xcshareddata/LFHeatMapDemo.xccheckout
@@ -5,34 +5,34 @@
 	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
 	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>03988669-6A70-4810-80A6-67AF1BE29709</string>
+	<string>C6E078FF-67EF-4AE4-AA36-3C9466A38D8B</string>
 	<key>IDESourceControlProjectName</key>
 	<string>LFHeatMapDemo</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>3E504400-AC4E-4B41-84C8-210CD3C578C9</key>
-		<string>ssh://github.com/gpolak/LFHeatMap.git</string>
+		<key>52423681-49D7-4640-AE0F-8E29A4140812</key>
+		<string>https://github.com/micazeve/LFHeatMap.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>LFHeatMapDemo/LFHeatMapDemo.xcodeproj/project.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>3E504400-AC4E-4B41-84C8-210CD3C578C9</key>
+		<key>52423681-49D7-4640-AE0F-8E29A4140812</key>
 		<string>../../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>ssh://github.com/gpolak/LFHeatMap.git</string>
+	<string>https://github.com/micazeve/LFHeatMap.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>3E504400-AC4E-4B41-84C8-210CD3C578C9</string>
+	<string>52423681-49D7-4640-AE0F-8E29A4140812</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>3E504400-AC4E-4B41-84C8-210CD3C578C9</string>
+			<string>52423681-49D7-4640-AE0F-8E29A4140812</string>
 			<key>IDESourceControlWCCName</key>
 			<string>LFHeatMap</string>
 		</dict>


### PR DESCRIPTION
Hi ! I have already worked on heatzone images, so I added some optimisations in your class.
When you fill the RGBA buffer, some tests can be avoided in order to save some time, by initializing the RGBA buffer to 0.
Second "optimization" was to remplace the time-consuming array shifting by setting the weight to a negative value and testing the weight. The tests are also time-consuming but it looks faster.
