### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Alternatively you can directly add the `LFHeatMap` folder to your project.
 This demo plots the measured magnitudes of the [2011 Virginia Earthquake](http://en.wikipedia.org/wiki/2011_Virginia_earthquake).
 
 ### Running
-1. Open and launch the LFHeatMapDemo XCode project. 
+1. Open and launch the LFHeatMapDemo Xcode project. 
 2. Move the slider on the bottom to adjust the boost.
 
 ### Explanation


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
